### PR TITLE
Refine global agentic-ai rules to problem-first design guidance

### DIFF
--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -13,13 +13,30 @@ globs: ["**/*"]
 - Follow the development rules (including code style, development language, etc.) of each project
 - Follow consistent naming conventions
 - Write self-documenting code with clear variable and function names
-- Prefer composition over inheritance
-- Use meaningful comments for complex business logic
 
-## Architecture Principles
+## Design Principles
 
-- Organize code by feature, not by file type
-- Keep related files close together
-- Use dependency injection for better testability
-- Implement proper error handling
-- Follow single responsibility principle
+- Design principles (SOLID, DRY, patterns, etc.) are tools, not goals. Identify a
+  concrete problem first (e.g., a change forces edits across multiple files, tests need
+  dependencies unrelated to what they verify), then apply a principle only when it beats
+  the simpler alternatives (inlining, a helper function, deletion). When in doubt, choose
+  the simpler option.
+- Do not add abstractions, layers, or interfaces for speculative future requirements (YAGNI).
+- Comments are a tool, not a goal. Add a comment only to explain why (intent, rationale,
+  non-obvious constraints), not what the code already states; do not add comments that
+  merely restate the code. When in doubt, improve names instead of adding a comment.
+
+## Dependency Injection
+
+- Inject only external boundaries: network, time, environment variables, logging.
+- Import pure functions and domain logic directly; do not inject them.
+- For fs, use the real module when tests can use a temporary directory (mkdtemp).
+- Do not add intermediate interfaces or wrappers that exist only for tests. When a mock
+  starts to reimplement production logic, it is a sign to revisit the design.
+
+## Error Handling
+
+- Let errors propagate by default; do not catch, log, and rethrow.
+- Wrap with `new Error(msg, { cause })` only where context (which target failed) is needed.
+- Centralize error logging in one place at the entry point (the `main` catch).
+- Emit a warning on the spot only when processing continues after a catch.


### PR DESCRIPTION
Replace named-principle imperatives (single responsibility, composition over inheritance, use DI, proper error handling) that get over-applied with problem-first meta-rules and concrete boundaries. Add Dependency Injection and Error Handling sections, and give code comments the same problem-first treatment. Keep the global file in English.


Claude-Session: https://claude.ai/code/session_01V6Qnod2WshhXr66GCxaPZK