### PR TITLE
コメント方針を三層＋provenance方針に置き換え

### DIFF
--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -22,9 +22,44 @@ globs: ["**/*"]
   the simpler alternatives (inlining, a helper function, deletion). When in doubt, choose
   the simpler option.
 - Do not add abstractions, layers, or interfaces for speculative future requirements (YAGNI).
-- Comments are a tool, not a goal. Add a comment only to explain why (intent, rationale,
-  non-obvious constraints), not what the code already states; do not add comments that
-  merely restate the code. When in doubt, improve names instead of adding a comment.
+
+## Comments
+
+Judge a comment by the trade-off between "the reader's effort saved at that spot" and
+"noise + drift cost". Do not judge by the what/why dichotomy. Use the three layers below.
+
+### 1. Guard comments — always keep
+
+A point that would puzzle someone reading the implementation, or a DO-NOT / pitfall to see
+when referencing it. Keep a rationale only when it satisfies **all** of:
+
+- Locality: the reason is specific to this spot (not a codebase-wide convention).
+- Non-recoverability: it cannot be read off types, signatures, error messages, or nearby code.
+- Guard nature: removing or changing it breaks something (i.e., it stops a future "improvement").
+- Not language-spec-obvious: not the likes of "a log appears where it is written".
+
+Keep "looks wrong but is correct" and "DO NOT X" cases minimal with a `NOTE:` prefix so the
+reasoning stays traceable.
+
+### 2. Convention why — once, at the definition/enforcement point
+
+Codebase-wide conventions (e.g., errors are rethrown at the leaf with context added to `cause`,
+and logged once in `main`) are not written at every application site. Write them once at the
+convention's enforcement point (root/main, or the relevant function). A leaf-level echo is a
+drift source — a convention change would force edits at every copy — and is forbidden.
+
+### 3. Single-line what — writer's discretion
+
+A single-line comment that serves as a heading for a following non-trivial multi-line block is
+fine (it aids top-to-bottom reading). A one-line paraphrase of a single self-named call has
+little value and is not required.
+
+### Do not keep provenance in code
+
+Design provenance ("who decided what, when, and why") belongs in ADR / PR / commit messages.
+History written in code rots. The only exception is the Guard case above (questions or DO-NOTs
+surfaced while reading the implementation); only then keep the essence of the provenance
+minimally with a `NOTE:` prefix.
 
 ## Dependency Injection
 


### PR DESCRIPTION
## 概要

`config/agentic-ai/.rulesync/rules/overview.md` のコメントガイドラインを、what/why の二分に基づく短い1項目から、トレードオフ（読み手の労力削減 vs ノイズ＋ドリフト費用）に基づく三層＋provenance 方針に置き換えます。

## 変更内容

Design Principles 内の短い「Comments」項目（3行）を削除し、独立した `## Comments` 節を新設:

- **層1 Guard comments — 必ず残す**: 局所性・非復元性・guard 性・非言語仕様自明の4条件をすべて満たす理由のみ残す。「一見おかしいが正しい」「DO NOT」は `NOTE:` 付きで最小限。
- **層2 Convention why — 定義／強制点に1回だけ**: コードベース規約は強制点（root/main または該当関数）に1回。leaf での echo はドリフト源として禁止。
- **層3 Single-line what — 書き手裁量**: 非自明な複数行ブロックの見出しは可、単一呼び出しの言い換えは不要。
- **Do not keep provenance in code**: 設計経緯は ADR/PR/コミットに残す。例外は Guard のみ、その場合 `NOTE:` で最小限。

## 補足

- 既存ファイルが全文英語のため、一貫性を優先して英語で記述しています。
- 元方針末尾の「具体例による妥当性確認」部分は、このリポジトリに存在しない別プロジェクトのファイルを参照した検証用の補足であり、ルール本体ではないため反映していません。
- 既存の Error Handling 節はコメント方針の「例」として参照されるのみで、規約自体の重複はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXWbyAkk4byCuFkvE46XYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXWbyAkk4byCuFkvE46XYT)_