### PR TITLE
Robustify bashrc PATH checks and skip no-op Claude settings rewrites

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -10,13 +10,15 @@
   export TMPDIR="/tmp"
 }
 
-[[ ! "$PATH" =~ "$HOME/bin" ]] && {
-  PATH="$HOME/bin:$PATH"
-}
+case ":$PATH:" in
+  *":$HOME/bin:"*) ;;
+  *) PATH="$HOME/bin:$PATH" ;;
+esac
 
-[[ ! "$PATH" =~ "$HOME/.local/bin" ]] && {
-  PATH="$HOME/.local/bin:$PATH"
-}
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) PATH="$HOME/.local/bin:$PATH" ;;
+esac
 
 [[ -d "/usr/games/bin" ]] && {
   PATH="/usr/games/bin:$PATH"
@@ -70,7 +72,12 @@ command -v jq >/dev/null 2>&1 && {
     "$HOME/.claude/settings.override.json" \
     > "$HOME/.claude/settings.json.tmp"
 
-  command mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"
+  if cmp -s "$HOME/.claude/settings.json" "$HOME/.claude/settings.json.tmp"
+  then
+    command rm "$HOME/.claude/settings.json.tmp"
+  else
+    command mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"
+  fi
 }
 
 [[ -f "$HOME/.bashrc_override" ]] && {


### PR DESCRIPTION
## 概要

bashrcの2点を改善します。挙動は既存実装の透過性を保ったまま、無駄な処理だけを省きます。

## 変更内容

- **PATHチェックを `case` パターンに統一**: `[[ "$PATH" =~ "$HOME/bin" ]]` は部分文字列マッチのため、例えば `$HOME/binaries` がPATHにあると誤ってスキップされます。pnpmブロックで既に使っている `case ":$PATH:" in *":$HOME/bin:"*)` 形式に揃えました。
- **Claude設定マージのno-opガード**: マージ結果を `cmp -s` で現行の `settings.json` と比較し、差分があるときだけ上書きするようにしました。マージロジック自体(`jq -s '.[0] * .[1]'`)は変更なしで、毎シェル起動時の無駄な書き込みだけがなくなります。

## 備考

初回だけはjqの整形差分で必ず1回書き込みが発生し、以降は安定します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtHjiR5Pv5PTHg9f9uHRgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtHjiR5Pv5PTHg9f9uHRgR)_