### PR TITLE
Harden vid2gif temp dir handling and make confirm prompt POSIX

### DIFF
--- a/local/bin/confirm
+++ b/local/bin/confirm
@@ -7,7 +7,7 @@ echo "$command $@"
 echo "are you sure you want to process these args by ${command} command?"
 
 while true; do
-  echo -n "(y/n): "
+  printf '(y/n): '
   read response
   if echo "$response" | grep -sq '^[yn]$'
   then

--- a/local/bin/vid2gif
+++ b/local/bin/vid2gif
@@ -1,12 +1,9 @@
 #!/bin/sh
-TMP_DIR="$HOME/${0##*/}.$(openssl rand -base64 12 | tr +/ -_)"
-mkdir "$TMP_DIR"
-do_exit() {
-	rm -r "$TMP_DIR"
-	exit
-}
-trap 'do_exit' 1 2 3 15
-[ ! -f "$1" ] && do_exit
+[ ! -f "$1" ] && exit 1
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -r "$TMP_DIR"' EXIT
+trap 'exit 1' HUP INT QUIT TERM
 
 SRC="${1##*/}"
 SRC_NAME="${SRC%.*}"
@@ -14,5 +11,3 @@ ffmpeg -i "$1" -vf \
 	fps=10,scale=iw:-1:flags=lanczos,palettegen "${TMP_DIR}/palette.png"
 ffmpeg -i "$1" -i "${TMP_DIR}/palette.png" -filter_complex \
 	fps=10,scale=iw:-1:flags=lanczos[x]\;[x][1:v]paletteuse "${SRC_NAME}.gif"
-
-do_exit


### PR DESCRIPTION
## 概要

`local/bin` スクリプト2本の堅牢化です。

## 変更内容

- **`vid2gif`**:
  - `$HOME` 直下に `openssl rand` で自作していた一時ディレクトリを `mktemp -d` に置き換え
  - クリーンアップを `EXIT` trapに変更(正常終了・シグナルどちらでも確実に削除。旧実装は末尾の `do_exit` 明示呼び出し頼みでした)
  - 入力ファイルが存在しない場合は非ゼロで終了(旧実装は0で終了)
- **`confirm`**: `echo -n` は `/bin/sh` の実装によって移植性がないため `printf '(y/n): '` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtHjiR5Pv5PTHg9f9uHRgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtHjiR5Pv5PTHg9f9uHRgR)_