### PR TITLE
Add timeout and error handling to confirm script user input

### DIFF
--- a/local/bin/confirm
+++ b/local/bin/confirm
@@ -8,7 +8,13 @@ echo "are you sure you want to process these args by ${command} command?"
 
 while true; do
   printf '(y/n): '
-  read response
+  response=$(timeout 10 sh -c 'IFS= read -r response && printf %s "$response"')
+  if [ $? -ne 0 ]
+  then
+    echo
+    echo "execution was blocked because human interaction is required"
+    exit 1
+  fi
   if echo "$response" | grep -sq '^[yn]$'
   then
     break


### PR DESCRIPTION
## Summary
Enhanced the `confirm` script to add a 10-second timeout for user input and proper error handling when interaction is blocked or times out.

## Key Changes
- Replaced simple `read` command with `timeout 10 sh -c 'IFS= read -r response && printf %s "$response"'` to enforce a 10-second timeout on user input
- Added exit code checking after the read operation
- Added user-friendly error message and exit with status code 1 when timeout occurs or human interaction is blocked
- Preserved the existing response validation logic for y/n answers

## Implementation Details
- The timeout wrapper ensures the script doesn't hang indefinitely waiting for user input
- Uses `IFS= read -r` to preserve the exact input without word splitting or backslash interpretation
- The `printf %s` ensures the response is captured without adding a newline
- Error handling provides clear feedback to users when the confirmation cannot be obtained within the time limit

https://claude.ai/code/session_012oYkYmWGtrM31MAMkTQRNU