### PR TITLE
Reframe Skills rules as stated-deviation defaults; add raw-deletion PreToolUse hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ in `~/.dotfileignore`.
 - `bashrc`, `profile`, `xprofile` — shell and X session setup
 - `config/` — XDG configs (`~/.config/…`): mise, bspwm, sxhkd, and
   `agentic-ai` (the rulesync source for Claude Code / Codex / Copilot)
-- `claude/settings.override.json` — repo-managed Claude Code permissions,
-  merged into `~/.claude/settings.json` by bashrc
+- `claude/settings.override.json` — repo-managed Claude Code permissions and
+  hooks, merged into `~/.claude/settings.json` by bashrc; hook scripts live in
+  `claude/hooks/`
 - `local/bin/` — small utility scripts (`~/.local/bin/…`)
 - `var/app/` — Flatpak app configs (VS Code)
 

--- a/claude/hooks/deny-raw-deletion.sh
+++ b/claude/hooks/deny-raw-deletion.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# PreToolUse hook (Bash matcher): deny raw deletion commands so removals route
+# through the safety-deletion skill (git rm / git clean) and stay recoverable.
+# Deterministic backstop for the Skills rule in agentic-ai overview.md — the
+# rule stays the primary layer; this only catches the cases where it is skipped.
+
+# Fail open: a missing jq must not break every Bash call.
+command -v jq >/dev/null 2>&1 || exit 0
+
+cmd=$(jq -r '.tool_input.command // empty') || exit 0
+[ -z "$cmd" ] && exit 0
+
+# Match deletion commands only in command position (start, or after ; & | $( `)
+# with optional sudo/env/command/nohup/xargs and a path prefix, so `git rm`,
+# `npm rm`, and option letters like `grep -rm` pass through.
+# NOTE: heuristic on the raw string — text inside quotes can false-positive
+# (e.g. a commit message containing "; rm "). Acceptable for a deny-with-reason
+# backstop: the agent can rephrase and retry.
+pos='(^|[;&|]|\$\(|`)[[:space:]]*'
+pre='((sudo|env|command|nohup|xargs)([[:space:]]+(-[^[:space:]]+|[A-Za-z_][A-Za-z_0-9]*=[^[:space:]]*))*[[:space:]]+)*'
+path='([^[:space:]]*/)?'
+
+if echo "$cmd" | grep -qE "${pos}${pre}${path}(rm|rmdir|shred|unlink)([[:space:]]|\$)" ||
+   echo "$cmd" | grep -qE "${pos}${pre}${path}truncate[[:space:]]" ||
+   echo "$cmd" | grep -qE "${pos}${pre}${path}find[[:space:]][^;&|]*(-delete|-exec[[:space:]]+([^[:space:]]*/)?rm[[:space:]])"
+then
+  echo "Raw deletion command blocked by ~/.claude/hooks/deny-raw-deletion.sh: use the safety-deletion skill (git rm / git clean) so the removal stays recoverable. If the target is outside git control, state the reason and ask the user before deleting." >&2
+  exit 2
+fi
+
+exit 0

--- a/claude/settings.override.json
+++ b/claude/settings.override.json
@@ -50,5 +50,18 @@
       "mcp__serena__get_diagnostics_for_symbol",
       "mcp__serena__get_symbols_overview"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/deny-raw-deletion.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -11,8 +11,8 @@ globs: ["**/*"]
 
 ## Skills
 
-Default choices, not absolute rules — but never skip one silently: a deviation must
-state its reason.
+Never skip one of these silently — deviating from a rule below requires stating the
+reason. Each rule carries its own strength and deviation condition.
 
 - File/directory deletion: in a git working tree, always use the `safety-deletion`
   skill (`git rm` / `git clean`) instead of `rm`, `find -delete`, etc. The only

--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -11,11 +11,17 @@ globs: ["**/*"]
 
 ## Skills
 
-- Before deleting files or directories by any means (`rm`, `find -delete`, etc.),
-  use the `safety-deletion` skill.
-- For symbol-level code search and navigation in a codebase, prefer the
-  `serena-semantic-search` skill over plain grep or whole-file reads (requires the
-  Serena MCP server).
+Default choices, not absolute rules — but never skip one silently: a deviation must
+state its reason.
+
+- File/directory deletion: in a git working tree, always use the `safety-deletion`
+  skill (`git rm` / `git clean`) instead of `rm`, `find -delete`, etc. The only
+  legitimate deviation is a target outside git control.
+- Symbol-level search across files (definitions, references, call sites): default to
+  the `serena-semantic-search` skill (requires the Serena MCP server). Plain grep,
+  line-range reads, and literal-text search are fine without it.
+- Design or refactoring judgment at a scale where opinions can diverge: use the
+  `design-review` skill. Trivial fixes do not need it.
 
 ## Design Principles
 
@@ -24,8 +30,7 @@ problem first (e.g., a change forces edits across multiple files, tests need dep
 unrelated to what they verify), then apply a principle only when it beats the simpler
 alternatives (inlining, a helper function, deletion). When in doubt, choose the simpler
 option. Do not add abstractions, layers, or interfaces for speculative future
-requirements (YAGNI). For a structured evaluation of a specific design or refactoring
-decision, use the `design-review` skill — the procedural form of this section.
+requirements (YAGNI). The `design-review` skill is the procedural form of this section.
 
 ## Comments
 

--- a/config/mise/tasks/agent-usage-report
+++ b/config/mise/tasks/agent-usage-report
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Report which tools and skills Claude Code invoked in recent sessions.
+# Usage: mise run agent-usage-report [days]   (default 7)
+# Window is file-mtime granularity: a session active within the window is
+# included whole, even if it started earlier.
+set -euo pipefail
+
+days="${1:-7}"
+projects="$HOME/.claude/projects"
+
+[ -d "$projects" ] || { echo "no transcripts under $projects"; exit 0; }
+
+# Count tool_use blocks only. A plain grep over the transcript JSONL
+# over-counts: per-session tool definitions and prompt text also contain tool
+# names, which shows up as a near-uniform floor across every tool of a server.
+usage="$(
+  find "$projects" -name '*.jsonl' -newermt "$days days ago" -exec cat {} + |
+    jq -Rr '
+      fromjson?
+      | .message.content[]?
+      | select(.type? == "tool_use")
+      | if .name == "Skill" then "skill\t" + (.input.skill? // "?")
+        else "tool\t" + .name end
+    '
+)"
+
+echo "# Tool/skill usage in sessions active in the last $days day(s)"
+echo
+echo "## Skills"
+awk -F'\t' '$1 == "skill" { print $2 }' <<<"$usage" | sort | uniq -c | sort -rn
+echo
+echo "## Tools"
+awk -F'\t' '$1 == "tool" { print $2 }' <<<"$usage" | sort | uniq -c | sort -rn


### PR DESCRIPTION
## 概要

#177 のフォローアップ。Opus 4.7 セッションでの利用状況観察を受けた変更に、別セッションのレビュー(相対化前置きの矛盾指摘・計測の欠如指摘)への対応を加えたものです。目的の優先順位は「スキルを適切な場面で使ってほしい」が優位、ただし逸脱の余地は理由の言語化つきで残す。

## 変更内容

### 1. Skills 節の再構成(`280ea02` + `8fb3dd8`)

命令形のみだった Skills 節を「各ルールが自分の強度と逸脱条件を語り、逸脱には理由の言語化を要求する」形式へ。当初案にあった相対化前置き("Default choices, not absolute rules")は、safety-deletion の "always" と同節内で矛盾し遵守率を下げる方向に働くため削除(`8fb3dd8`)。残るのはスキップへの摩擦のみ:

> Never skip one of these silently — deviating from a rule below requires stating the reason. Each rule carries its own strength and deviation condition.

- **safety-deletion**: 「git 作業ツリー内では常に使う」を維持。逸脱条件は「git 管理外の対象のみ」と列挙型で限定
- **serena-semantic-search**: 適用範囲を「ファイル横断のシンボルレベル検索」に明確化
- **design-review**: Design Principles 末尾から Skills 節へ昇格し、発動閾値(「判断が割れうる規模。1行修正には不要」)を付与

### 2. 生削除コマンドを拒否する PreToolUse hook(`3851194`)

- `claude/hooks/deny-raw-deletion.sh`: コマンド位置の `rm` / `rmdir` / `shred` / `unlink` / `truncate` と `find -delete` / `find -exec rm` を exit 2 で拒否し、safety-deletion skill へ誘導。`git rm`・`git clean`・`npm rm`・`grep -rm` 等は通過(block 13 / pass 9 ケースでテスト済み)
- jq 欠如・不正入力時はフェイルオープン(Bash ツール全体を壊さない)
- `claude/settings.override.json` に hooks 設定を追加(bashrc の `jq -s '.[0] * .[1]'` マージは hooks 配列を上書き置換する点に注意)、README の Layout 記述を更新

### 3. agent-usage-report mise task(`1ac3aed`)

直近 N 日(デフォルト7)のセッションで実際に呼び出されたツール・スキルを transcripts の **tool_use ブロックのみから**集計する。

```sh
mise run agent-usage-report        # 直近7日
mise run agent-usage-report 30    # 直近30日
```

素の grep での集計はツール定義やプロンプト本文中のツール名まで数えてしまい、サーバーの全ツールにほぼ一様な下駄(セッション数相当)が乗る — 実測時に `mcp__serena__rename_memory` 等の未使用ツールが 137 件と出たのはこれ。tool_use 限定の抽出で解消。

## 効果計測

#177/#183 の文言変更の効果検証は `agent-usage-report` の before/after 比較で行い、結論が出るまでこれ以上の文言調整はしない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hm8V3fpaGNyNs1qZjJCdGC