### PR TITLE
confirm: run timeout in foreground to accept tty input

### DIFF
--- a/local/bin/confirm
+++ b/local/bin/confirm
@@ -8,7 +8,7 @@ echo "are you sure you want to process these args by ${command} command?"
 
 while true; do
   printf '(y/n): '
-  response=$(timeout 10 sh -c 'IFS= read -r response && printf %s "$response"')
+  response=$(timeout --foreground 10 sh -c 'IFS= read -r response && printf %s "$response"')
   if [ $? -ne 0 ]
   then
     echo


### PR DESCRIPTION
timeout runs its child in a separate process group by default, so the read stopped with SIGTTIN when reading from the terminal and y/n input was never accepted. Use timeout --foreground so the prompt can read from the tty while keeping the 10-second block behavior.


Claude-Session: https://claude.ai/code/session_012oYkYmWGtrM31MAMkTQRNU