### PR TITLE
Clarify file deletion rules and improve prevention messaging

### DIFF
--- a/claude/hooks/deny-raw-deletion.sh
+++ b/claude/hooks/deny-raw-deletion.sh
@@ -24,7 +24,7 @@ if echo "$cmd" | grep -qE "${pos}${pre}${path}(rm|rmdir|shred|unlink)([[:space:]
    echo "$cmd" | grep -qE "${pos}${pre}${path}truncate[[:space:]]" ||
    echo "$cmd" | grep -qE "${pos}${pre}${path}find[[:space:]][^;&|]*(-delete|-exec[[:space:]]+([^[:space:]]*/)?rm[[:space:]])"
 then
-  echo "Raw deletion command blocked by ~/.claude/hooks/deny-raw-deletion.sh: use the safety-deletion skill (git rm / git clean) so the removal stays recoverable. If the target is outside git control, state the reason and ask the user before deleting." >&2
+  echo "Raw deletion command blocked by ~/.claude/hooks/deny-raw-deletion.sh: use the safety-deletion skill — git rm for tracked paths, git clean for untracked/ignored ones — so the removal stays recoverable. Untracked is not an exemption. Next time, create scratch/temp files under \$TMPDIR (mktemp -d) instead of the working tree; files there need no cleanup." >&2
   exit 2
 fi
 

--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -15,8 +15,10 @@ Never skip one of these silently — deviating from a rule below requires statin
 reason. Each rule carries its own strength and deviation condition.
 
 - File/directory deletion: in a git working tree, always use the `safety-deletion`
-  skill (`git rm` / `git clean`) instead of `rm`, `find -delete`, etc. The only
-  legitimate deviation is a target outside git control.
+  skill (`git rm` for tracked paths, `git clean` for untracked/ignored ones)
+  instead of `rm`, `find -delete`, etc. Untracked is not an exemption. Avoid
+  needing deletion at all: create scratch/temp files under `$TMPDIR`
+  (`mktemp -d`), not the working tree; files there need no cleanup.
 - Symbol-level search across files (definitions, references, call sites): default to
   the `serena-semantic-search` skill (requires the Serena MCP server). Plain grep,
   line-range reads, and literal-text search are fine without it.


### PR DESCRIPTION
## Summary
Updated documentation and error messaging for the file deletion safety rules to provide clearer guidance on proper deletion practices and emphasize prevention strategies.

## Key Changes
- **Rules documentation** (`overview.md`):
  - Clarified that `git clean` should be used for untracked/ignored files, while `git rm` is for tracked paths
  - Removed the "outside git control" exemption and instead emphasized prevention: create temporary files under `$TMPDIR` using `mktemp -d` rather than in the working tree
  - Reframed the rule to discourage deletion needs altogether rather than just managing how deletions occur

- **Hook error message** (`deny-raw-deletion.sh`):
  - Updated the blocked command message to match the clarified rules
  - Specified the distinction between `git rm` (tracked) and `git clean` (untracked/ignored)
  - Removed the exemption for files outside git control
  - Added guidance to use `$TMPDIR` for temporary files to avoid cleanup needs entirely

## Implementation Details
The changes shift the philosophy from "delete safely when needed" to "avoid needing deletion by using proper temporary file locations." This reduces operational risk by preventing accumulation of temporary files in the working tree and ensures all deletions remain recoverable through git's mechanisms.

https://claude.ai/code/session_01LDQJBL1akzEdBtgG78MPuf