### PR TITLE
Clarify symbol-level search guidance in agentic AI rules

### DIFF
--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -19,9 +19,14 @@ reason. Each rule carries its own strength and deviation condition.
   instead of `rm`, `find -delete`, etc. Untracked is not an exemption. Avoid
   needing deletion at all: create scratch/temp files under `$TMPDIR`
   (`mktemp -d`), not the working tree; files there need no cleanup.
-- Symbol-level search across files (definitions, references, call sites): default to
-  the `serena-semantic-search` skill (requires the Serena MCP server). Plain grep,
-  line-range reads, and literal-text search are fine without it.
+- Before grepping an identifier (a function/class/method/variable name) to find
+  where it is defined, referenced, implemented, or called — or before reading a
+  whole source file just to understand its structure: that intent is symbol-level
+  search, even if it feels like an ordinary grep. Use the `serena-semantic-search`
+  skill (requires the Serena MCP server) instead. When starting to read an
+  implementation file, lead with a symbol overview rather than a full-file read.
+  Literal-text search (strings, error messages, config keys), line-range reads,
+  and non-code files stay on plain grep/Read.
 - Design or refactoring judgment at a scale where opinions can diverge: use the
   `design-review` skill. Trivial fixes do not need it.
 


### PR DESCRIPTION
## Summary
Updated the symbol-level search rule in the agentic AI overview to provide clearer guidance on when to use semantic search versus plain grep, with emphasis on using symbol-level search as the default approach for code navigation tasks.

## Key Changes
- Expanded the rule to explicitly define what constitutes "symbol-level search" (finding definitions, references, implementations, and call sites of identifiers)
- Clarified that this intent applies even when the task might feel like an ordinary grep operation
- Added guidance to lead with symbol overview rather than full-file reads when starting to understand implementation files
- Refined the distinction between symbol-level search (use `serena-semantic-search`) and literal-text search (use plain grep), with examples of literal-text use cases (strings, error messages, config keys)
- Improved readability and specificity of the rule to help users make better tool choices

## Implementation Details
The changes reframe the rule from a passive suggestion ("default to semantic search") to active guidance that helps users recognize when they're performing symbol-level search tasks, even if they initially think of them as simple grep operations. This should reduce unnecessary full-file reads and improve the use of semantic search capabilities.

https://claude.ai/code/session_01HrcKSQ665ZNuwcSq12GFTx