### PR TITLE
Add pre-commit checklist guidance to agentic AI rules

### DIFF
--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -30,6 +30,15 @@ reason. Each rule carries its own strength and deviation condition.
 - Design or refactoring judgment at a scale where opinions can diverge: use the
   `design-review` skill. Trivial fixes do not need it.
 
+## Before Committing
+
+Before every commit, check the project's task manifest (`package.json` scripts,
+`Makefile`, `justfile`, `deno.json` tasks, etc.) and run the tasks that correspond to
+formatting/linting and testing. Report the results; do not commit with failing checks
+unless the failure pre-exists the change and is unrelated (say so explicitly).
+Deviation condition: when the full test suite is too heavy, run only the tests
+relevant to the change and state that you narrowed the scope.
+
 ## Design Principles
 
 Design principles (SOLID, DRY, patterns, etc.) are tools, not goals. Identify a concrete


### PR DESCRIPTION
## Summary
Added a new "Before Committing" section to the agentic AI rules overview to establish clear expectations for code quality checks before commits.

## Key Changes
- Introduced a new "Before Committing" section in the rules overview that outlines the requirement to run formatting, linting, and testing tasks before committing
- Specified that developers should check the project's task manifest (package.json scripts, Makefile, justfile, deno.json tasks, etc.) for relevant tasks
- Clarified that test results must be reported and commits should not proceed with failing checks unless the failure pre-exists the change
- Added a deviation condition allowing scope reduction for heavy test suites, with explicit documentation required

## Details
This guidance reinforces quality standards by making pre-commit verification a documented expectation rather than an implicit practice. The rule acknowledges practical constraints (heavy test suites) while maintaining accountability through explicit reporting of scope decisions.

https://claude.ai/code/session_011x3DDzgCx4jBwvE7mBHczn