### PR TITLE
Wire docs-restructuring and align comment-pruning trigger

### DIFF
--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -30,10 +30,11 @@ reason. Each rule carries its own strength and deviation condition.
 - Design or refactoring judgment at a scale where opinions can diverge: use the
   `design-review` skill. Trivial fixes do not need it.
 - After a multi-iteration change settles — before opening or finalizing a PR —
-  or whenever a touched file's comments narrate development history ("since
-  #NNN", "previously", "per review"), use the `comment-pruning` skill to
-  re-judge accumulated comments against the Comments policy below. Do not run
-  it mid-implementation; pruning while the code is still moving causes churn.
+  or whenever a touched file's annotations narrate development history, point
+  at code that has moved, or pack more facts per block than a reader can hold,
+  use the `comment-pruning` skill to re-judge them against the Comments policy
+  below. Do not run it mid-implementation; pruning while the code is still
+  moving causes churn.
 
 ## Before Committing
 

--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -35,6 +35,10 @@ reason. Each rule carries its own strength and deviation condition.
   use the `comment-pruning` skill to re-judge them against the Comments policy
   below. Do not run it mid-implementation; pruning while the code is still
   moving causes churn.
+- When documentation *structure* has failed — a heading tree that no longer
+  predicts content, or one section mixing concepts, invariants, and
+  procedures — use the `docs-restructuring` skill first, then `comment-pruning`
+  for per-unit tightening. Routine tidying needs only the latter.
 
 ## Before Committing
 

--- a/config/agentic-ai/.rulesync/rules/overview.md
+++ b/config/agentic-ai/.rulesync/rules/overview.md
@@ -35,10 +35,6 @@ reason. Each rule carries its own strength and deviation condition.
   use the `comment-pruning` skill to re-judge them against the Comments policy
   below. Do not run it mid-implementation; pruning while the code is still
   moving causes churn.
-- When documentation *structure* has failed — a heading tree that no longer
-  predicts content, or one section mixing concepts, invariants, and
-  procedures — use the `docs-restructuring` skill first, then `comment-pruning`
-  for per-unit tightening. Routine tidying needs only the latter.
 
 ## Before Committing
 

--- a/config/mise/tasks/setup-agent-skills
+++ b/config/mise/tasks/setup-agent-skills
@@ -12,6 +12,7 @@ skills=(
   "google/skills google-cloud-networking-observability"
   "knokmki612/skills comment-pruning"
   "knokmki612/skills design-review"
+  "knokmki612/skills docs-restructuring"
   "knokmki612/skills safety-deletion"
   "knokmki612/skills serena-semantic-search"
   "knokmki612/skills wip-commit-organization"


### PR DESCRIPTION
## Summary

Follow-up to the skills-side changes (comment-pruning broadened; docs-restructuring added): update the rules and skill setup to match.

## Changes

- **Align the comment-pruning trigger with the broadened rubric** (`.rulesync/rules/overview.md`): the skill now also targets drifted references (annotations pointing at code that has moved) and overloaded blocks (more facts per block than a reader can hold), not only history narration — widen the trigger wording accordingly.
- **Install docs-restructuring**: add `knokmki612/skills docs-restructuring` to the `setup-agent-skills` mise task so it installs/updates alongside the other skills.
- **Deliberately no always-loaded rule for docs-restructuring**: the Skills rules exist to change the agent's default behavior during routine work. docs-restructuring is rare, human-initiated, and approval-gated — invocation is covered by the installed skill's own description matching, and discovery during routine work is covered by comment-pruning's report handing off structural findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ac9jy86dNdcA2R17YhQBop