### PR TITLE
chore(nvim): drop symlink for nonexistent ftplugin dir

### DIFF
--- a/local/bin/setup-nvim.sh
+++ b/local/bin/setup-nvim.sh
@@ -9,10 +9,6 @@ mkdir -p "${NVIM_DIR}" "${NVIM_DIR}/colors"
   ln -sf "${VIM_DIR}/vimrc" "${NVIM_DIR}/init.vim"
 }
 
-[ -d "${VIM_DIR}/ftplugin" ] && {
-  ln -sf "${VIM_DIR}/ftplugin" "${NVIM_DIR}/"
-}
-
 [ -d "${VIM_DIR}/ftdetect" ] && {
   ln -sf "${VIM_DIR}/ftdetect" "${NVIM_DIR}/"
 }


### PR DESCRIPTION
## 概要

`local/bin/setup-nvim.sh` から、存在しない `ftplugin` ディレクトリを symlink しようとする空振りブロックを削除します。

## 背景

`setup-nvim.sh` は `~/.vim`（vim-config）の設定を Neovim（`~/.config/nvim`）にリンクするスクリプトです。しかし vim-config 側は `Remove ftplugin/sass.vim` 以降 `ftplugin/` ディレクトリを持たないため、`[ -d "${VIM_DIR}/ftplugin" ]` のガードは常に false となり、当該ブロックはデッドコードになっていました。

## 変更内容

- `ftplugin` の symlink ブロックを削除（1 file changed, 4 deletions）
- 実体のある `ftdetect` / `init.vim` / colorscheme のリンクはそのまま維持

## 影響

挙動に変化はありません（元々空振りしていたコードの除去のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLF58zW84QxXvTxPaqQRyr)_